### PR TITLE
Fixed typo in post-boot-machine.sh

### DIFF
--- a/post-boot-machine.sh
+++ b/post-boot-machine.sh
@@ -35,7 +35,7 @@ if [ ! -f "${JREWIN}" ]; then
 fi
 if [ ! -f "${SELENIUM}" ]; then
 	downloads_needed=1
-	echo "SeleniumGridEstras-*.jar missing, download into ${DOWNLOADS} from https://github.com/groupon/Selenium-Grid-Extras/releases" >&2
+	echo "SeleniumGridExtras-*.jar missing, download into ${DOWNLOADS} from https://github.com/groupon/Selenium-Grid-Extras/releases" >&2
 fi
 if [ ! -f "${IEDRIVER}" ]; then
 	downloads_needed=1


### PR DESCRIPTION
Non-critical typo fix. Just threw me for a loop when I was debugging.